### PR TITLE
Fix missing qt modules

### DIFF
--- a/flatpak_option.patch
+++ b/flatpak_option.patch
@@ -1,0 +1,203 @@
+From 843909f0215fa0ef0a6b41db380d3aae09b25b7f Mon Sep 17 00:00:00 2001
+From: Shyamnath Premnadh <Shyamnath.Premnadh@qt.io>
+Date: Thu, 25 Jul 2024 15:21:51 +0200
+Subject: [PATCH 1/3] PySide Build: Fix SHIBOKEN_DEBUG_LEVEL environment
+ variable setting
+
+- checking if the environment variable was set used the wrong CMake
+  syntax
+
+Pick-to: 6.7
+Change-Id: Ib186a8ed10e66c074c22c24a43bf5a3b67cc9ffc
+Reviewed-by: Alexandru Croitor <alexandru.croitor@qt.io>
+---
+ sources/shiboken6/cmake/ShibokenHelpers.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sources/shiboken6/cmake/ShibokenHelpers.cmake b/sources/shiboken6/cmake/ShibokenHelpers.cmake
+index cff6df95e..27ee33305 100644
+--- a/sources/shiboken6/cmake/ShibokenHelpers.cmake
++++ b/sources/shiboken6/cmake/ShibokenHelpers.cmake
+@@ -882,7 +882,7 @@ function(shiboken_get_debug_level out_var)
+     set(debug_level "")
+     if(SHIBOKEN_DEBUG_LEVEL)
+         set(debug_level "--debug-level=${SHIBOKEN_DEBUG_LEVEL}")
+-    elseif(DEFINED $ENV{SHIBOKEN_DEBUG_LEVEL})
++    elseif(DEFINED ENV{SHIBOKEN_DEBUG_LEVEL})
+         set(debug_level "--debug-level=$ENV{SHIBOKEN_DEBUG_LEVEL}")
+     endif()
+     set(${out_var} "${debug_level}" PARENT_SCOPE)
+-- 
+2.34.1
+
+
+From 3ff86e67a97ddca53df2732846112f3fe783d2c2 Mon Sep 17 00:00:00 2001
+From: Shyamnath Premnadh <Shyamnath.Premnadh@qt.io>
+Date: Fri, 26 Jul 2024 10:50:53 +0200
+Subject: [PATCH 2/3] PySide Build: Add an option to provide extra include
+ paths for Shiboken
+
+- Expands on 7cc5c139482d735c49002649d26bb524c92cc86b, by creating a
+  build option '--shiboken-extra-include-paths' that appends extra
+  include paths to the '--force-process-system-include-paths' option
+  when calling shiboken generator to create PySide6 modules.
+- This can be helpful for Flatpak and OS Distro builds of PySide6.
+
+Pick-to: 6.7
+Change-Id: Ibd4c9702a741d8047ccaf53d84a1c97550d78ffe
+---
+ build_scripts/main.py                     |  9 +++++++++
+ build_scripts/options.py                  |  8 +++++++-
+ sources/pyside6/cmake/PySideHelpers.cmake | 12 +++++++++++-
+ 3 files changed, 27 insertions(+), 2 deletions(-)
+
+diff --git a/build_scripts/main.py b/build_scripts/main.py
+index 506a9891f..1b5fee450 100644
+--- a/build_scripts/main.py
++++ b/build_scripts/main.py
+@@ -613,6 +613,15 @@ class PysideBuild(_build, CommandMixin, BuildInfoCollectorMixin):
+             cmake_cmd.append("-DPYSIDE_TREAT_QT_INCLUDE_DIRS_AS_NON_SYSTEM=ON")
+             log.info("Shiboken will now process system Qt headers")
+ 
++        if OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS']:
++            extra_include_paths = ''
++            for path in OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS'].split(','):
++                if extra_include_paths:
++                    extra_include_paths += ';'
++                extra_include_paths += path
++            cmake_cmd.append(f"-DSHIBOKEN_FORCE_PROCESS_SYSTEM_INCLUDE_PATHS={extra_include_paths}")
++            log.info(f"Shiboken will now process system headers from: {extra_include_paths}")
++
+         cmake_cmd += [
+             "-G", self.make_generator,
+             f"-DBUILD_TESTS={self.build_tests}",
+diff --git a/build_scripts/options.py b/build_scripts/options.py
+index 731ac8087..3442d2667 100644
+--- a/build_scripts/options.py
++++ b/build_scripts/options.py
+@@ -254,7 +254,11 @@ class CommandMixin(object):
+         # This option is specific for Flatpak and OS distro builds of PySide6. So, use with
+         # caution as it may also try to parse other global headers.
+         ('shiboken-force-process-system-headers', None,
+-         'When building PySide against system Qt, shiboken does not ignore the system Qt headers')
++         'When building PySide against system Qt, shiboken does not ignore the system Qt headers'),
++        # shiboken-extra-inlude-paths option is specifically used to tell the clang inside shiboken
++        # to include extra paths when parsing the headers. Use with caution.
++        ('shiboken-extra-include-paths=', None,
++         'Extra include paths for shiboken. Comma separated.'),
+     ]
+ 
+     def __init__(self):
+@@ -317,6 +321,7 @@ class CommandMixin(object):
+         self.no_unity = False
+         self.unity_build_batch_size = "16"
+         self.shiboken_force_process_system_headers = False
++        self.shiboken_extra_include_paths = None
+ 
+         # When initializing a command other than the main one (so the
+         # first one), we need to copy the user options from the main
+@@ -438,6 +443,7 @@ class CommandMixin(object):
+         OPTION['UNITY'] = not self.no_unity
+         OPTION['UNITY_BUILD_BATCH_SIZE'] = self.unity_build_batch_size
+         OPTION['SHIBOKEN_FORCE_PROCESS_SYSTEM_HEADERS'] = self.shiboken_force_process_system_headers
++        OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS'] = self.shiboken_extra_include_paths
+ 
+         qtpaths_abs_path = None
+         if self.qtpaths and Path(self.qtpaths).exists():
+diff --git a/sources/pyside6/cmake/PySideHelpers.cmake b/sources/pyside6/cmake/PySideHelpers.cmake
+index 01c438107..48502f384 100644
+--- a/sources/pyside6/cmake/PySideHelpers.cmake
++++ b/sources/pyside6/cmake/PySideHelpers.cmake
+@@ -236,7 +236,17 @@ macro(collect_module_if_found shortname)
+     # If the module was found, and also the module path is the same as the
+     # Qt5Core base path, we will generate the list with the modules to be installed
+     set(looked_in_message ". Looked in: ${${_name_dir}}")
+-    if("${${_name_found}}" AND (("${found_basepath}" GREATER "0") OR ("${found_basepath}" EQUAL "0")))
++
++    # 'found_basepath' is used to ensure consistency that all the modules are from the same Qt
++    # directory which prevents issues from arising due to mixing versions or using incompatible Qt
++    # modules. When SHIBOKEN_FORCE_PROCESS_SYSTEM_INCLUDE_PATHS is not empty, we can ignore this
++    # requirement of 'found_basepath'.
++    # This is specifically useful for Flatpak build of PySide6 where For Flatpak the modules are in
++    # different directories. For Flatpak, although the modules are in different directories, they
++    # are all compatible.
++    if("${${_name_found}}" AND
++       ((("${found_basepath}" GREATER "0") OR ("${found_basepath}" EQUAL "0")) OR
++        (NOT SHIBOKEN_FORCE_PROCESS_SYSTEM_INCLUDE_PATHS STREQUAL "")))
+         message(STATUS "${module_state} module ${name} found (${ARGN})${looked_in_message}")
+         # record the shortnames for the tests
+         list(APPEND all_module_shortnames ${shortname})
+-- 
+2.34.1
+
+
+From 75ff562443d2369aae2f0d3755d16cdd75a707a6 Mon Sep 17 00:00:00 2001
+From: Shyamnath Premnadh <Shyamnath.Premnadh@qt.io>
+Date: Fri, 26 Jul 2024 11:04:20 +0200
+Subject: [PATCH 3/3] PySide Build: Add --flatpak option
+
+- The new option is to enable a flatpak build of Qt for Python. This
+  does the following things:
+  1. It turns the option --shiboken_force_process_system_headers ON
+    by default.
+  2, It adds the include path '/app/include' to the option
+    --shiboken_extra_include_paths.
+    The problem with the KDE Flatpak SDK is that certain modules:
+    QtPdf, QtPdfWidgets, QtWebEngineCore, QtWebEngineQuick,
+    QtWebEngineWidgets, are not available and hences the headers
+    are not present in '/usr/include'. Therefore we use the Flatpak
+    WebEngine BaseApp as the base app for our Flatpak PySide6 BaseApp.
+    This has the headers for the missing modules, but in '/app/include'
+    instead of '/usr/include'.
+    This patch passes '/app/include' as an additional include path
+    to shiboken when building the Python bindings for the above
+    mentioned missing modules.
+
+Pick-to: 6.7
+Change-Id: I4e393007040c9d07dca1878027c224b63e3be5d7
+---
+ build_scripts/options.py | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/build_scripts/options.py b/build_scripts/options.py
+index 3442d2667..922df2486 100644
+--- a/build_scripts/options.py
++++ b/build_scripts/options.py
+@@ -259,6 +259,15 @@ class CommandMixin(object):
+         # to include extra paths when parsing the headers. Use with caution.
+         ('shiboken-extra-include-paths=', None,
+          'Extra include paths for shiboken. Comma separated.'),
++        # flatpak option is used to build PySide6 for Flatpak. Flatpak is a special case where
++        # some of the headers for the Qt modules are located as system headers in /usr/include in
++        # the KDE flatpak SDK. Therefore --shiboken-force-process-system headers will be by
++        # default enabled when --flatpak is enabled.
++        # Apart from that, headers for certain Qt modules like QtWebEngine, QtPdf etc. are located
++        # in /app/include from the Flapak WebEngine baseapp. Therefore when the --flatpak option is
++        # enabled, the extra include path of /app/include will be added to the option
++        # --shiboken-extra-include-paths.
++        ('flatpak', None, 'Build PySide6 for Flatpak.'),
+     ]
+ 
+     def __init__(self):
+@@ -322,6 +331,7 @@ class CommandMixin(object):
+         self.unity_build_batch_size = "16"
+         self.shiboken_force_process_system_headers = False
+         self.shiboken_extra_include_paths = None
++        self.flatpak = False
+ 
+         # When initializing a command other than the main one (so the
+         # first one), we need to copy the user options from the main
+@@ -444,6 +454,10 @@ class CommandMixin(object):
+         OPTION['UNITY_BUILD_BATCH_SIZE'] = self.unity_build_batch_size
+         OPTION['SHIBOKEN_FORCE_PROCESS_SYSTEM_HEADERS'] = self.shiboken_force_process_system_headers
+         OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS'] = self.shiboken_extra_include_paths
++        OPTION['FLATPAK'] = self.flatpak
++        if OPTION['FLATPAK']:
++            OPTION['SHIBOKEN_FORCE_PROCESS_SYSTEM_HEADERS'] = True
++            OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS'] = '/app/include'
+ 
+         qtpaths_abs_path = None
+         if self.qtpaths and Path(self.qtpaths).exists():
+-- 
+2.34.1
+

--- a/flatpak_option.patch
+++ b/flatpak_option.patch
@@ -30,8 +30,7 @@ index cff6df95e..27ee33305 100644
 -- 
 2.34.1
 
-
-From 3ff86e67a97ddca53df2732846112f3fe783d2c2 Mon Sep 17 00:00:00 2001
+From b9dad02a19a084c00fed88600cd67f3cff614bb2 Mon Sep 17 00:00:00 2001
 From: Shyamnath Premnadh <Shyamnath.Premnadh@qt.io>
 Date: Fri, 26 Jul 2024 10:50:53 +0200
 Subject: [PATCH 2/3] PySide Build: Add an option to provide extra include
@@ -46,25 +45,21 @@ Subject: [PATCH 2/3] PySide Build: Add an option to provide extra include
 Pick-to: 6.7
 Change-Id: Ibd4c9702a741d8047ccaf53d84a1c97550d78ffe
 ---
- build_scripts/main.py                     |  9 +++++++++
+ build_scripts/main.py                     |  5 +++++
  build_scripts/options.py                  |  8 +++++++-
  sources/pyside6/cmake/PySideHelpers.cmake | 12 +++++++++++-
- 3 files changed, 27 insertions(+), 2 deletions(-)
+ 3 files changed, 23 insertions(+), 2 deletions(-)
 
 diff --git a/build_scripts/main.py b/build_scripts/main.py
-index 506a9891f..1b5fee450 100644
+index 506a9891f..da132f0e0 100644
 --- a/build_scripts/main.py
 +++ b/build_scripts/main.py
-@@ -613,6 +613,15 @@ class PysideBuild(_build, CommandMixin, BuildInfoCollectorMixin):
+@@ -613,6 +613,11 @@ class PysideBuild(_build, CommandMixin, BuildInfoCollectorMixin):
              cmake_cmd.append("-DPYSIDE_TREAT_QT_INCLUDE_DIRS_AS_NON_SYSTEM=ON")
              log.info("Shiboken will now process system Qt headers")
  
 +        if OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS']:
-+            extra_include_paths = ''
-+            for path in OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS'].split(','):
-+                if extra_include_paths:
-+                    extra_include_paths += ';'
-+                extra_include_paths += path
++            extra_include_paths = ';'.join(OPTION['SHIBOKEN_EXTRA_INCLUDE_PATHS'].split(','))
 +            cmake_cmd.append(f"-DSHIBOKEN_FORCE_PROCESS_SYSTEM_INCLUDE_PATHS={extra_include_paths}")
 +            log.info(f"Shiboken will now process system headers from: {extra_include_paths}")
 +
@@ -130,8 +125,7 @@ index 01c438107..48502f384 100644
 -- 
 2.34.1
 
-
-From 75ff562443d2369aae2f0d3755d16cdd75a707a6 Mon Sep 17 00:00:00 2001
+From e6aabc488976156122e6a4d073b10111775a127f Mon Sep 17 00:00:00 2001
 From: Shyamnath Premnadh <Shyamnath.Premnadh@qt.io>
 Date: Fri, 26 Jul 2024 11:04:20 +0200
 Subject: [PATCH 3/3] PySide Build: Add --flatpak option

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -13,13 +13,15 @@ build-options:
   append-ld-library-path: /usr/lib/sdk/llvm16/lib
   env:
     LLVM_INSTALL_DIR: /usr/lib/sdk/llvm16
+    SHIBOKEN_DEBUG_LEVEL: 'full'
 modules:
   - python3-requirements.json
   - name: pyside-setup
     buildsystem: simple
     build-commands:
       - python3 setup.py build --qtpaths=/usr/bin/qtpaths --ignore-git --parallel=8
-        --log-level=verbose --no-qt-tools --shiboken-force-process-system-headers
+        --log-level=verbose --no-qt-tools --flatpak
+      - cat /run/build/pyside-setup/build/qfp-py3.11-qt6.7.2-64bit-release/build/pyside6/PySide6/QtPdf/mjb_rejected_classes.log
       - python3 create_wheels.py --build-dir ./build/qfp-*-release
       - pip install ./dist/*.whl --prefix=${FLATPAK_DEST}
     sources:
@@ -28,6 +30,8 @@ modules:
         tag: "6.7.2"
       - type: patch
         path: shiboken_force_process_system_headers.patch
+      - type: patch
+        path: flatpak_option.patch
   - name: polish
     buildsystem: simple
     build-commands:

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -28,13 +28,9 @@ modules:
         tag: "6.7.2"
       - type: patch
         path: shiboken_force_process_system_headers.patch
-    cleanup:
-      - ${FLATPAK_DEST}/bin/pyside6-*
-      - ${FLATPAK_DEST}/lib/python*/site-packages/PySide6/scripts
   - name: polish
     buildsystem: simple
     build-commands:
-      - echo "Polishing the app..."
       - mv ${FLATPAK_DEST}/cleanup-BaseApp{,-QtWebEngine}.sh
       - install -Dm755 cleanup.sh ${FLATPAK_DEST}/cleanup-BaseApp.sh
       - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/

--- a/io.qt.PySide.BaseApp.yaml
+++ b/io.qt.PySide.BaseApp.yaml
@@ -21,7 +21,6 @@ modules:
     build-commands:
       - python3 setup.py build --qtpaths=/usr/bin/qtpaths --ignore-git --parallel=8
         --log-level=verbose --no-qt-tools --flatpak
-      - cat /run/build/pyside-setup/build/qfp-py3.11-qt6.7.2-64bit-release/build/pyside6/PySide6/QtPdf/mjb_rejected_classes.log
       - python3 create_wheels.py --build-dir ./build/qfp-*-release
       - pip install ./dist/*.whl --prefix=${FLATPAK_DEST}
     sources:


### PR DESCRIPTION
- Cleanup the manifest
- Fix missing builds for the modules - QtPdf, QtPdfWidgets, QtWebEngineCore, QtWebEngineQuick,
QtWebEngineWidgets.
The file 'flatpak_option.patch' is a mix of the following commits from Qt for Python which is required for the PySide 6.7.2. When Kde updates the Qt version in its SDK, we can remove them. 
1. https://codereview.qt-project.org/c/pyside/pyside-setup/+/578851
2. https://codereview.qt-project.org/c/pyside/pyside-setup/+/579019
3.  https://codereview.qt-project.org/c/pyside/pyside-setup/+/579021/1